### PR TITLE
GCP-98 build fix

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,4 +2,5 @@ FROM faizanbashir/python-datascience:3.6
 COPY requirements.txt /
 COPY train.py /
 WORKDIR /
+RUN apk add libffi-dev python3-dev
 RUN pip3 install -r requirements.txt

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,5 +23,6 @@ steps:
     - |
        python3 /workspace/bin/kfp_deploy.py ${_KUBEFLOW_HOST} "${REPO_NAME}-${SHORT_SHA}" /workspace/conf/workflow.yaml
 
+timeout: 900s
 substitutions:
   _IMAGE_NAME: train-iris


### PR DESCRIPTION
Added missing dependencies and extended default build time out as certain dependencies need to be built locally